### PR TITLE
FIREFOX: Add new Salesforce setup URL to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
         {
           "js": ["content.js"],
           "matches": [
-            "*://*.lightning.force.com/lightning/setup/*"
+            "*://*.lightning.force.com/lightning/setup/*",
+            "*://*.salesforce-setup.com/lightning/setup/*"
           ],
           "run_at": "document_end"
         }


### PR DESCRIPTION
Recently Salesforce updates to the new `salesforce-setup.com` has broken compatibility with the current version of the Firefox extension.

While this has been fixed for Chrome the Firefox version is still out of date. Just adds support for the new URL - copied from https://github.com/walters954/why-salesforce/commit/b0d08444521c8b0531382fdc937cbfdf95271a46

Addresses #22 

This is one of my favourite SF extensions, would greatly appreciate any update to FF if possible :) Cheers!