### PR TITLE
Lots of changes - reordering tabs, automatic updates, show tabs on front end, new saves settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This extension allows users to create custom tabs in Setup for their most-used s
 -   [x] Ability to customize tab
     -   [x] Salesforce SLDS
     -   [x] Feedback on save and delete
-    -   [ ] Update tabs onSave without refresh
+    -   [x] Update tabs on save with automatic refresh
     -   [x] Disable save button if tabs list empty
-    -   [ ] Reorder tabs
+    -   [x] Reorder tabs
 -   [x] Minify SLDS files
 -   [ ] Dark mode for flows
 -   [ ] Org specific tab customization

--- a/content.js
+++ b/content.js
@@ -98,6 +98,7 @@ function delayLoadSetupTabs(count) {
             let styles = [`background-color:${settings.backgroundColor || 'white'}`,
                           'border-bottom:1px solid lightgray',
                           `color:${settings.fontColor || 'black'}`];
+            if (settings.extraUlStyles) {styles.push(settings.extraUlStyles);}
 
             return !settings.displayOnTop ? allTabs : `<ul class="slds-grid" style="${styles.join(';')}">${allTabs}</ul>`;
         }

--- a/content.js
+++ b/content.js
@@ -7,7 +7,7 @@ runOrSkip();
 
 function runOrSkip() {
     chrome.storage.sync.get([storageKeySettings], function (items) {
-        settings = items[storageKeySettings];
+        settings = items[storageKeySettings] || {};
         Object.defineProperty(settings, 'displayOnTop', { get() {return !isSetup || this.tabsOnTopInSetup;} });
 
         // console.log('SETTINGS: ', settings);

--- a/content.js
+++ b/content.js
@@ -1,98 +1,121 @@
-const storageKey = "sfmWhySF";
+const storageKeySettings = "sfmWhySF_settings";
+const storageKeyTabs     = "sfmWhySF_tabs";
+const isSetup            = window.location.pathname.indexOf('/lightning/setup/') != -1;
+let settings;
 
-function init(setupTabUl) {
-    if (setupTabUl) {
-        let rows = [];
-        chrome.storage.sync.get([storageKey], function (items) {
-            let rowObj = items[storageKey] || [];
-            if (rowObj.length === 0) {
-                //Did not find data inside browser storage
-                rowObj = initTabs();
-            }
+runOrSkip();
 
-            for (const rowId in rowObj) {
-                let row = rowObj[rowId];
-                rows.push(
-                    generateRowTemplate(row.tabTitle, row.url, row.openInNewTab)
-                );
-            }
-            setupTabUl.insertAdjacentHTML("beforeend", rows.join(""));
+function runOrSkip() {
+    chrome.storage.sync.get([storageKeySettings], function (items) {
+        settings = items[storageKeySettings];
+        Object.defineProperty(settings, 'displayOnTop', { get() {return !isSetup || this.tabsOnTopInSetup;} });
 
-            // Add click event listeners after rows are inserted
-            addClickEventListeners();
-        });
-    }
-}
+        // console.log('SETTINGS: ', settings);
 
-function delayLoadSetupTabs(count) {
-    const setupTabUl = document.getElementsByClassName(
-        "tabBarItems slds-grid"
-    )[0];
-    count++;
+        let run = (isSetup && settings.showInSetup) || (!isSetup && settings.showInFront);
 
-    if (count > 5) {
-        console.log("Why Salesforce - failed to find setup tab.");
-        return;
-    }
-
-    if (!setupTabUl) {
-        setTimeout(function () {
-            delayLoadSetupTabs(count);
-        }, 3000); // Fixed to pass count correctly
-    } else {
-        init(setupTabUl);
-    }
-}
-
-setTimeout(function () {
-    delayLoadSetupTabs(0);
-}, 3000);
-
-function generateRowTemplate(tabTitle, url, openInNewTab) {
-    const target = openInNewTab ? "_blank" : "_self";
-    return `<li role="presentation" class="oneConsoleTabItem tabItem slds-context-bar__item borderRight navexConsoleTabItem" data-aura-class="navexConsoleTabItem" data-url="${url}">
-            <a role="tab" tabindex="-1" title="${tabTitle}" aria-selected="false" href="${url}" target="${target}" class="tabHeader slds-context-bar__label-action">
-                <span class="title slds-truncate">${tabTitle}</span>
-            </a>
-        </li>`;
-}
-
-function initTabs() {
-    let tabs = [
-        { tabTitle: "Home", url: "/", openInNewTab: false },
-        {
-            tabTitle: "Flow",
-            url: "/lightning/setup/Flows/home",
-            openInNewTab: true,
-        },
-        {
-            tabTitle: "User",
-            url: "/lightning/setup/ManageUsers/home",
-            openInNewTab: false,
-        },
-    ];
-
-    chrome.storage.sync.set({ sfmWhySF: tabs }, function () {
-        //TODO combine with popup.js with background service
-    });
-    return tabs;
-}
-
-function addClickEventListeners() {
-    chrome.storage.sync.get([storageKey], function (items) {
-        const rowObj = items[storageKey] || [];
-        for (const rowId in rowObj) {
-            let tab = rowObj[rowId];
-            document
-                .querySelectorAll(`a[href="${tab.url}"]`)
-                .forEach((link) => {
-                    link.addEventListener("click", function (event) {
-                        if (tab.openInNewTab) {
-                            event.preventDefault();
-                            window.open(tab.url, "_blank");
-                        }
-                    });
-                });
+        if (run) {
+            setTimeout(function () {
+                delayLoadSetupTabs(0);
+            }, 1000);
         }
     });
 }
+
+function delayLoadSetupTabs(count) {
+    const insertionElement = settings.displayOnTop ? document.getElementById('oneHeader') : document.getElementsByClassName("tabBarItems slds-grid")[0];
+    count++;
+
+    if (count > 5) {
+        console.log("Why Salesforce - failed to find insertion point.");
+        return;
+    }
+
+    if (!insertionElement) {
+        setTimeout(function () {
+            delayLoadSetupTabs(count);
+        }, 3000);
+    } else {
+        init(insertionElement);
+    }
+}
+    function init(insertionElement) {
+        if (insertionElement) {
+            let tabs = [];
+            chrome.storage.sync.get([storageKeyTabs], function (items) {
+                let tabsData = items[storageKeyTabs] || [];
+
+                if (tabsData.length === 0) {
+                    //Did not find data inside browser storage
+                    tabsData = initTabs();
+                }
+
+                tabsData.forEach(tabData => {
+                    tabs.push(
+                        generateRowTemplate(tabData.tabTitle, tabData.url, tabData.openInNewTab)
+                    );
+                });
+
+                let insertionPosition = settings.displayOnTop ? "afterbegin" : "beforeend";
+                insertionElement.insertAdjacentHTML(insertionPosition, content(tabs));
+
+                // Add click event listeners after rows are inserted
+                addClickEventListeners();
+            });
+        }
+    }
+        function initTabs() {
+            let tabs = [
+                { tabTitle: "Home", url: "/", openInNewTab: false },
+                {
+                    tabTitle: "Flow",
+                    url: "/lightning/setup/Flows/home",
+                    openInNewTab: true,
+                },
+                {
+                    tabTitle: "User",
+                    url: "/lightning/setup/ManageUsers/home",
+                    openInNewTab: false,
+                },
+            ];
+
+            chrome.storage.sync.set({ sfmWhySF_tabs: tabs }, function () {
+                //TODO combine with popup.js with background service
+            });
+            return tabs;
+        }
+        function generateRowTemplate(tabTitle, url, openInNewTab) {
+            const target = openInNewTab ? "_blank" : "_self";
+
+            return `<li role="presentation" class="oneConsoleTabItem tabItem slds-context-bar__item borderRight navexConsoleTabItem" style="height:36px" data-aura-class="navexConsoleTabItem" data-url="${url}">
+                        <a role="tab" tabindex="-1" title="${tabTitle}" aria-selected="false" href="${url}" target="${target}" class="tabHeader slds-context-bar__label-action">
+                            <span class="title slds-truncate">${tabTitle}</span>
+                        </a>
+                    </li>`;
+        }
+        function content(tabs) {
+            let allTabs = tabs.join("");
+            let styles = [`background-color:${settings.backgroundColor || 'white'}`,
+                          'border-bottom:1px solid lightgray',
+                          `color:${settings.fontColor || 'black'}`];
+
+            return !settings.displayOnTop ? allTabs : `<ul class="slds-grid" style="${styles.join(';')}">${allTabs}</ul>`;
+        }
+        function addClickEventListeners() {
+            chrome.storage.sync.get([storageKeyTabs], function (items) {
+                const rowObj = items[storageKeyTabs] || [];
+                for (const rowId in rowObj) {
+                    let tab = rowObj[rowId];
+                    document
+                        .querySelectorAll(`a[href="${tab.url}"]`)
+                        .forEach((link) => {
+                            link.addEventListener("click", function (event) {
+                                if (tab.openInNewTab) {
+                                    event.preventDefault();
+                                    window.open(tab.url, "_blank");
+                                }
+                            });
+                        });
+                }
+            });
+        }

--- a/manifest.json
+++ b/manifest.json
@@ -1,27 +1,27 @@
 {
-    "manifest_version": 3,
-    "name": "Why Salesforce",
-    "version": "1.5",
-    "permissions": ["storage"],
-    "description": "Stuff that Salesforce should have added already... Adding flow and user tabs into setup.",
-    "content_scripts": [
-        {
-            "js": ["content.js"],
-            "matches": [
-                "*://*.lightning.force.com/lightning/setup/*",
-                "*://*.salesforce-setup.com/lightning/setup/*"
-            ],
-            "run_at": "document_end"
-        }
-    ],
-    "icons": {
-        "16": "images/whysf16.png",
-        "32": "images/whysf32.png",
-        "48": "images/whysf48.png",
-        "128": "images/whysf128.png"
-    },
-    "action": {
-        "default_title": "Why Salesforce",
-        "default_popup": "popup.html"
-    }
+   "manifest_version": 3,
+   "name": "Why Salesforce",
+   "version": "1.6",
+   "permissions": ["storage"],
+   "description": "Stuff that Salesforce should have added already... omni-present custom tabs for whatever you want.",
+   "content_scripts": [
+       {
+           "js": ["content.js"],
+           "matches": [
+               "*://*.lightning.force.com/*",
+               "*://*.salesforce-setup.com/lightning/setup/*"
+           ],
+           "run_at": "document_end"
+       }
+   ],
+   "icons": {
+       "16": "images/whysf16.png",
+       "32": "images/whysf32.png",
+       "48": "images/whysf48.png",
+       "128": "images/whysf128.png"
+   },
+   "action": {
+       "default_title": "Why Salesforce",
+       "default_popup": "popup.html"
+   }
 }

--- a/popup.css
+++ b/popup.css
@@ -1,7 +1,49 @@
 body {
-    width: 40rem;
+    width: 50rem;
 }
 
 .hidden{
     display: none;
 }
+
+.subheader {
+    background-color: var(--slds-g-color-neutral-base-95,#f3f3f3);
+    border-top: 1px solid var(--slds-g-color-border-base-1, #e5e5e5);
+    border-bottom: 1px solid var(--slds-g-color-border-base-1, #e5e5e5);
+    color: var(--slds-g-color-neutral-base-30, #444);
+    cursor: pointer;
+    font-weight: bold;
+    padding: .25rem 1.5rem;
+}
+.subheader::before {
+    content: "▼ ";
+    margin-left: -1em;
+}
+
+#settings-container.collapsed .subheader::before {
+    content: "▶︎ ";
+}
+#settings-container.collapsed .settings {
+    display: none;
+}
+.settings {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
+}
+
+.setting.row {
+    align-items: center;
+    display: flex;
+    padding: .25rem 2.5rem;
+}
+.setting.row label {
+    flex-grow: 1;
+    font-weight: bold;
+}
+.setting.row input {flex-basis: 8rem}
+.setting.row:hover {background-color: rgb(243, 243, 243)}
+
+input.order {padding-right: 0}
+input[type="checkbox"]:hover {cursor: pointer}
+input[type="checkbox"]:focus {box-shadow: none}

--- a/popup.css
+++ b/popup.css
@@ -41,8 +41,10 @@ body {
     flex-grow: 1;
     font-weight: bold;
 }
-.setting.row input {flex-basis: 8rem}
+.setting.row input {flex-basis: 10rem}
 .setting.row:hover {background-color: rgb(243, 243, 243)}
+.setting.row.secret {display: none}
+#settings-container .settings.show-secrets .setting.row.secret {display: inherit}
 
 input.order {padding-right: 0}
 input[type="checkbox"]:hover {cursor: pointer}

--- a/popup.html
+++ b/popup.html
@@ -43,7 +43,7 @@
             <div id="settings-container">
                 <div class="subheader">Settings</div>
                 <div class="settings">
-                    <!-- Setting rows will be dynamically added here -->
+                    <!-- Settings rows will be dynamically added here -->
                 </div>
             </div>
 
@@ -75,7 +75,7 @@
     </article>
 
     <template id="settings_template">
-        <div class="setting row showInFront">
+        <!-- <div class="setting row showInFront">
             <label>Display in Front End</label>
             <input type="checkbox" name="showInFront" class="slds-input slds-checkbox">
         </div>
@@ -98,59 +98,7 @@
         <div class="setting row fontColor">
             <label>Font Color</label>
             <input type="text" name="fontColor" class="slds-input" placeholder="CSS colors">
-        </div>
-    </template>
-
-
-    <template id="settings_template_old">
-        <tr class="setting showInFront">
-            <td data-label="Setting Label" scope="row">
-                <div class="slds-form-element__control">
-                    Display in Front End
-                </div>
-            </td>
-            <td data-label="Setting Value">
-                <div class="slds-form-element__control">
-                    <input type="checkbox" name="showInFront" class="slds-checkbox setting-input">
-                </div>
-            </td>
-        </tr>
-        <tr class="setting showInSetup">
-            <td scope="row">
-                <div class="slds-form-element__control">
-                    Display in Setup
-                </div>
-            </td>
-            <td>
-                <div class="slds-form-element__control">
-                    <input type="checkbox" name="showInSetup" class="slds-checkbox setting-input">
-                </div>
-            </td>
-        </tr>
-        <tr class="setting tabsOnTopInSetup">
-            <td scope="row">
-                <div class="slds-form-element__control">
-                    Tabs on Top in Setup (vs besides Object Manager tab)
-                </div>
-            </td>
-            <td>
-                <div class="slds-form-element__control">
-                    <input type="checkbox" name="tabsOnTopInSetup" class="slds-checkbox setting-input">
-                </div>
-            </td>
-        </tr>
-        <tr class="setting refreshAfterSave">
-            <td scope="row">
-                <div class="slds-form-element__control">
-                    Refresh After Saving
-                </div>
-            </td>
-            <td>
-                <div class="slds-form-element__control">
-                    <input type="checkbox" name="refreshAfterSave" class="slds-checkbox setting-input">
-                </div>
-            </td>
-        </tr>
+        </div> -->
     </template>
 
     <template id="tr_template">

--- a/popup.html
+++ b/popup.html
@@ -53,16 +53,16 @@
                         <th scope="col" style="width: 5rem">
                             <div title="Order">Order</div>
                         </th>
-                        <th scope="col">
+                        <th scope="col" style="width: 13rem">
                             <div title="Tab Name">Tab Name</div>
                         </th>
                         <th scope="col">
                             <div title="Tab Url">Tab Url</div>
                         </th>
-                        <th scope="col" style="width: 3.25rem">
+                        <th scope="col" style="width: 4rem">
                             <div title="Open in New Tab">New Tab</div>
                         </th>
-                        <th scope="col" style="width: 3.25rem">
+                        <th scope="col" style="width: 6rem">
                             <div class="slds-assistive-text" title="Actions">Actions</div>
                         </th>
                     </tr>
@@ -73,33 +73,6 @@
             </table>
         </div>
     </article>
-
-    <template id="settings_template">
-        <!-- <div class="setting row showInFront">
-            <label>Display in Front End</label>
-            <input type="checkbox" name="showInFront" class="slds-input slds-checkbox">
-        </div>
-        <div class="setting row showInSetup">
-            <label>Display in Setup</label>
-            <input type="checkbox" name="showInSetup" class="slds-input slds-checkbox">
-        </div>
-        <div class="setting row tabsOnTopInSetup">
-            <label>Tabs on Top in Setup (vs beside Object Manager tab)</label>
-            <input type="checkbox" name="tabsOnTopInSetup" class="slds-input slds-checkbox">
-        </div>
-        <div class="setting row refreshAfterSave">
-            <label>Refresh After Saving</label>
-            <input type="checkbox" name="refreshAfterSave" class="slds-input slds-checkbox">
-        </div>
-        <div class="setting row backgroundColor">
-            <label>Background Color</label>
-            <input type="text" name="backgroundColor" class="slds-input" placeholder="CSS colors">
-        </div>
-        <div class="setting row fontColor">
-            <label>Font Color</label>
-            <input type="text" name="fontColor" class="slds-input" placeholder="CSS colors">
-        </div> -->
-    </template>
 
     <template id="tr_template">
         <tr class="tab">

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./assets/salesforce-lightning-design-system.min.css">
     <title>Tab Manager</title>
 </head>
+
 <body class="slds-p-around_none">
     <article class="slds-card">
         <div class="slds-card__header slds-grid">
@@ -39,9 +40,19 @@
             </div>
         </div>
         <div class="slds-card__body slds-card__body_inner slds-p-around_none">
+            <div id="settings-container">
+                <div class="subheader">Settings</div>
+                <div class="settings">
+                    <!-- Setting rows will be dynamically added here -->
+                </div>
+            </div>
+
             <table class="slds-table slds-table_cell-buffer slds-table_bordered">
                 <thead>
                     <tr>
+                        <th scope="col" style="width: 5rem">
+                            <div title="Order">Order</div>
+                        </th>
                         <th scope="col">
                             <div title="Tab Name">Tab Name</div>
                         </th>
@@ -57,14 +68,98 @@
                     </tr>
                 </thead>
                 <tbody class="tabs">
-                    <!-- Rows will be dynamically added here -->
+                    <!-- Tab rows will be dynamically added here -->
                 </tbody>
             </table>
         </div>
     </article>
 
+    <template id="settings_template">
+        <div class="setting row showInFront">
+            <label>Display in Front End</label>
+            <input type="checkbox" name="showInFront" class="slds-input slds-checkbox">
+        </div>
+        <div class="setting row showInSetup">
+            <label>Display in Setup</label>
+            <input type="checkbox" name="showInSetup" class="slds-input slds-checkbox">
+        </div>
+        <div class="setting row tabsOnTopInSetup">
+            <label>Tabs on Top in Setup (vs beside Object Manager tab)</label>
+            <input type="checkbox" name="tabsOnTopInSetup" class="slds-input slds-checkbox">
+        </div>
+        <div class="setting row refreshAfterSave">
+            <label>Refresh After Saving</label>
+            <input type="checkbox" name="refreshAfterSave" class="slds-input slds-checkbox">
+        </div>
+        <div class="setting row backgroundColor">
+            <label>Background Color</label>
+            <input type="text" name="backgroundColor" class="slds-input" placeholder="CSS colors">
+        </div>
+        <div class="setting row fontColor">
+            <label>Font Color</label>
+            <input type="text" name="fontColor" class="slds-input" placeholder="CSS colors">
+        </div>
+    </template>
+
+
+    <template id="settings_template_old">
+        <tr class="setting showInFront">
+            <td data-label="Setting Label" scope="row">
+                <div class="slds-form-element__control">
+                    Display in Front End
+                </div>
+            </td>
+            <td data-label="Setting Value">
+                <div class="slds-form-element__control">
+                    <input type="checkbox" name="showInFront" class="slds-checkbox setting-input">
+                </div>
+            </td>
+        </tr>
+        <tr class="setting showInSetup">
+            <td scope="row">
+                <div class="slds-form-element__control">
+                    Display in Setup
+                </div>
+            </td>
+            <td>
+                <div class="slds-form-element__control">
+                    <input type="checkbox" name="showInSetup" class="slds-checkbox setting-input">
+                </div>
+            </td>
+        </tr>
+        <tr class="setting tabsOnTopInSetup">
+            <td scope="row">
+                <div class="slds-form-element__control">
+                    Tabs on Top in Setup (vs besides Object Manager tab)
+                </div>
+            </td>
+            <td>
+                <div class="slds-form-element__control">
+                    <input type="checkbox" name="tabsOnTopInSetup" class="slds-checkbox setting-input">
+                </div>
+            </td>
+        </tr>
+        <tr class="setting refreshAfterSave">
+            <td scope="row">
+                <div class="slds-form-element__control">
+                    Refresh After Saving
+                </div>
+            </td>
+            <td>
+                <div class="slds-form-element__control">
+                    <input type="checkbox" name="refreshAfterSave" class="slds-checkbox setting-input">
+                </div>
+            </td>
+        </tr>
+    </template>
+
     <template id="tr_template">
         <tr class="tab">
+            <td data-label="Order">
+                <div class="slds-form-element__control">
+                    <input type="number" min="0" step="1" name="Order" class="order slds-input">
+                </div>
+            </td>
             <td data-label="Tab Name" scope="row">
                 <div class="slds-form-element__control">
                     <input type="text" name="tabTitle" class="tabTitle slds-input" placeholder="Flow">
@@ -77,7 +172,7 @@
             </td>
             <td data-label="New Tab">
                 <div class="slds-form-element__control">
-                    <input type="checkbox" name="openInNewTab" class="openInNewTab slds-checkbox">
+                    <input type="checkbox" name="openInNewTab" class="openInNewTab slds-input slds-checkbox">
                 </div>
             </td>
             <td>

--- a/popup.html
+++ b/popup.html
@@ -157,7 +157,7 @@
         <tr class="tab">
             <td data-label="Order">
                 <div class="slds-form-element__control">
-                    <input type="number" min="0" step="1" name="Order" class="order slds-input">
+                    <input type="number" min="1" step="1" name="Order" class="order slds-input">
                 </div>
             </td>
             <td data-label="Tab Name" scope="row">

--- a/popup.js
+++ b/popup.js
@@ -11,8 +11,10 @@ const settingsInfo       = {collapsed:        {type: 'hidden',   default: true},
                             showInSetup:      {type: 'checkbox', default: true,              label: 'Display in Setup'},
                             tabsOnTopInSetup: {type: 'checkbox', default: false,             label: 'Tabs on Top in Setup (vs beside Object Manager tab)'},
                             refreshAfterSave: {type: 'checkbox', default: true,              label: 'Refresh After Saving'},
-                            backgroundColor:  {type: 'text',     default: 'white',           label: 'Background Color', placeholder: 'CSS-compatible colors'},
-                            fontColor:        {type: 'text',     default: 'rgb(24, 24, 24)', label: 'Font Color',       placeholder: 'CSS-compatible colors'}};
+                            backgroundColor:  {type: 'text',     default: 'white',           label: 'Background Color',                    placeholder: 'CSS-compatible colors'},
+                            fontColor:        {type: 'text',     default: 'rgb(24, 24, 24)', label: 'Font Color',                          placeholder: 'CSS-compatible colors'},
+                            extraUlStyles:    {type: 'text',     secret: true,               label: 'Extra Styles For Tab Container (ul)', placeholder: 'border:none;font-weight:bold'}
+                        };
 
 loadSettings();
 loadTabs();
@@ -38,8 +40,8 @@ function loadSettings() {
             let settingHTML;
             const settingInfo = settingsInfo[settingName];
 
-            if (settingInfo.type == 'checkbox' || settingInfo.type == 'text') {
-                settingHTML = `<div class="setting row ${settingName}">
+            if (settingInfo.type != 'hidden') {
+                settingHTML = `<div class="setting row ${settingName} ${settingInfo.secret ? 'secret' : ''}">
                                    <label>${settingInfo.label}</label>
                                    <input type="${settingInfo.type}" name="${settingName}" class="slds-input ${settingInfo.type == 'checkbox' ? 'slds-checkbox' : ''}" ${settingInfo.placeholder ? 'placeholder="' + settingInfo.placeholder + '"' : ''}>
                                </div>`;
@@ -61,7 +63,7 @@ function loadSettings() {
                         settingsElement.querySelector(`.setting.${settingName} input`).checked = storedSettings?.[settingName] ?? settingInfo.default;
                         break;
                     case 'text':
-                        settingsElement.querySelector(`.setting.${settingName} input`).value = storedSettings?.[settingName] || settingInfo.default;
+                        settingsElement.querySelector(`.setting.${settingName} input`).value = storedSettings?.[settingName] || settingInfo.default || '';
                         break;
                 }
             });
@@ -95,6 +97,11 @@ function loadTabs() {
 function toggleSettingsCollapse() {
     const settingsContainer = document.getElementById('settings-container');
     settingsContainer.classList.toggle('collapsed');
+}
+
+function toggleSecretSettings() {
+    const settingsContainer = document.querySelector('#settings-container .settings');
+    settingsContainer.classList.toggle('show-secrets');
 }
 
 function addTab() {
@@ -209,6 +216,9 @@ saveButton.addEventListener("click", saveTab);
 
 const addButton = document.querySelector(".add");
 addButton.addEventListener("click", addTab);
+
+const brandImage = document.querySelector("header img");
+brandImage.addEventListener("dblclick", toggleSecretSettings);
 
 // Initial check to set the state of the save button
 updateSaveButtonState();

--- a/popup.js
+++ b/popup.js
@@ -113,15 +113,18 @@ function processTabs() {
         let tabTitle     = tab.querySelector(".tabTitle").value;
         let url          = tab.querySelector(".url").value;
         let openInNewTab = tab.querySelector(".openInNewTab").checked;
-        let order        = tab.querySelector(".order").value;
+        let order        = Number(tab.querySelector(".order").value);
+        if (order == 0) {order = null;}
 
         if (tabTitle && url) {
             tabs.push({ tabTitle, url, openInNewTab, order });
         }
     });
 
-    let sortedTabs = tabs.sort((a, b) => a.order - b.order);
-    return sortedTabs;
+    // Sorts tabs by order with nulls at the end
+    tabs.sort((a, b) => (a.order === null) - (b.order === null) || +(a.order > b.order) || -(a.order < b.order));
+
+    return tabs;
 }
 
 function deleteTab() {

--- a/popup.js
+++ b/popup.js
@@ -40,19 +40,6 @@ function loadSettings() {
         document.querySelector(settingsAppendElement).append(template.content);
     });
 }
-// function loadSettings() {
-//     const template = document.getElementById(settingsTemplate);
-
-//     chrome.storage.sync.get([storageKeySettings], function (items) {
-//         const settings = items[storageKeySettings];
-
-//         Object.keys(settingDefaults).forEach(setting => {
-//             template.content.querySelector(`.setting.${setting} .setting-input`).checked = settings?.[setting] ?? settingDefaults[setting];
-//         });
-
-//         document.querySelector(settingsAppendElement).append(template.content);
-//     });
-// }
 
 function loadTabs() {
     const template = document.getElementById(tabTemplate);

--- a/popup.js
+++ b/popup.js
@@ -53,10 +53,10 @@ function loadSettings() {
         chrome.storage.sync.get([storageKeySettings], function (items) {
             const storedSettings = items[storageKeySettings];
 
+            if (storedSettings?.collapsed ?? settingsInfo.collapsed.default) {toggleSettingsCollapse();}
+
             Object.keys(settingsInfo).forEach(settingName => {
                 let settingInfo = settingsInfo[settingName];
-
-                if (storedSettings?.collapsed ?? settingsInfo.collapsed.default) {toggleSettingsCollapse();}
 
                 switch(settingInfo.type) {
                     case 'checkbox':


### PR DESCRIPTION
Supports reordering tabs
Added collapsable Settings area in popup so user can manage options:
Option to update tabs on save with automatic refresh
Option to display tabs on front end (instead of just setup)
Option to set tab background and font colors

Also...
Increased size of checkboxes so they're easier to click without increasing line height
Adjusted some code formatting outside of my key changes to improve readability and consistency
Updated version to 1.6

Note: I refer to the main, non-setup area of Salesforce as "Front End". Honestly, I don't love it, but I don't know what else to call it.