### PR TITLE
Reorder tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This extension allows users to create custom tabs in Setup for their most-used s
     -   [x] Feedback on save and delete
     -   [ ] Update tabs onSave without refresh
     -   [x] Disable save button if tabs list empty
-    -   [ ] Reorder tabs
+    -   [x] Reorder tabs
 -   [x] Minify SLDS files
 -   [ ] Dark mode for flows
 -   [ ] Org specific tab customization

--- a/popup.css
+++ b/popup.css
@@ -1,7 +1,31 @@
 body {
-    width: 40rem;
+    width: 50rem;
 }
 
 .hidden{
     display: none;
+}
+
+.header-buttons .tab-mover {
+    display: none;
+    font-weight: bold;
+}
+.header-buttons.radio-selected .tab-mover {
+    display: unset;
+}
+.header-buttons .tab-mover.down {
+    margin-right: 15rem;
+}
+
+tr.tab.selected {
+    background-color: lightgray;
+}
+td[data-label="Reorder"] {
+    text-align: center;
+}
+
+input[type="radio"] {
+    position: relative;
+    top: 2px;
+    transform: scale(2);
 }

--- a/popup.css
+++ b/popup.css
@@ -1,20 +1,25 @@
 body {
-    width: 50rem;
+    width: 45rem;
 }
 
 .hidden{
     display: none;
 }
 
-.header-buttons .tab-mover {
+.header-buttons .tab-action {
     display: none;
     font-weight: bold;
 }
-.header-buttons.radio-selected .tab-mover {
+.header-buttons.radio-selected .tab-action {
     display: unset;
 }
-.header-buttons .tab-mover.down {
-    margin-right: 15rem;
+.header-buttons .tab-action.down {
+    margin-right: 2rem;
+}
+.header-buttons .delete {
+    height: 32px;
+    margin-right: 9rem;
+    vertical-align: bottom;
 }
 
 tr.tab.selected {

--- a/popup.html
+++ b/popup.html
@@ -24,8 +24,17 @@
                     </h2>
                 </div>
                 <div class="slds-no-flex header-buttons">
-                    <button class="tab-mover up slds-button slds-button_brand" style="transform: scale(1, -1)">⇩</button>
-                    <button class="tab-mover down slds-button slds-button_brand">⇩</button>
+                    <button class="tab-action up slds-button slds-button_brand" style="transform: scale(1, -1)">⇩</button>
+                    <button class="tab-action down slds-button slds-button_brand">⇩</button>
+
+                    <button class="tab-action delete slds-button slds-button_destructive">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="-5 0 60 60" fill="#fff">
+                            <path
+                                d="M45.5 10H33V6a4 4 0 0 0-4-4h-6a4 4 0 0 0-4 4v4H6.5c-.8 0-1.5.7-1.5 1.5v3c0 .8.7 1.5 1.5 1.5h39c.8 0 1.5-.7 1.5-1.5v-3c0-.8-.7-1.5-1.5-1.5zM23 7c0-.6.4-1 1-1h4c.6 0 1 .4 1 1v3h-6zm18.5 13h-31c-.8 0-1.5.7-1.5 1.5V45a5 5 0 0 0 5 5h24a5 5 0 0 0 5-5V21.5c0-.8-.7-1.5-1.5-1.5zM23 42c0 .6-.4 1-1 1h-2c-.6 0-1-.4-1-1V28c0-.6.4-1 1-1h2c.6 0 1 .4 1 1zm10 0c0 .6-.4 1-1 1h-2c-.6 0-1-.4-1-1V28c0-.6.4-1 1-1h2c.6 0 1 .4 1 1z">
+                            </path>
+                        </svg>
+                    </button>
+
                     <button class="save slds-button slds-button_brand">Save</button>
                     <button class="add slds-button slds-button_neutral">Add</button>
                 </div>
@@ -55,9 +64,6 @@
                         </th>
                         <th scope="col" style="width: 4rem">
                             <div title="Open in New Tab">New Tab</div>
-                        </th>
-                        <th scope="col" style="width: 6rem">
-                            <div class="slds-assistive-text" title="Actions">Actions</div>
                         </th>
                     </tr>
                 </thead>
@@ -89,9 +95,6 @@
                 <div class="slds-form-element__control">
                     <input type="checkbox" name="openInNewTab" class="openInNewTab slds-checkbox">
                 </div>
-            </td>
-            <td>
-                <button class="delete slds-button slds-button_destructive">Delete</button>
             </td>
         </tr>
     </template>

--- a/popup.html
+++ b/popup.html
@@ -23,7 +23,9 @@
                         <span>Why Salesforce</span>
                     </h2>
                 </div>
-                <div class="slds-no-flex">
+                <div class="slds-no-flex header-buttons">
+                    <button class="tab-mover up slds-button slds-button_brand" style="transform: scale(1, -1)">⇩</button>
+                    <button class="tab-mover down slds-button slds-button_brand">⇩</button>
                     <button class="save slds-button slds-button_brand">Save</button>
                     <button class="add slds-button slds-button_neutral">Add</button>
                 </div>
@@ -42,16 +44,19 @@
             <table class="slds-table slds-table_cell-buffer slds-table_bordered">
                 <thead>
                     <tr>
-                        <th scope="col">
+                        <th scope="col" style="width: 1px">
+                            <div title="Reorder">Reorder</div>
+                        </th>
+                        <th scope="col" style="width: 13rem">
                             <div title="Tab Name">Tab Name</div>
                         </th>
                         <th scope="col">
                             <div title="Tab Url">Tab Url</div>
                         </th>
-                        <th scope="col" style="width: 3.25rem">
+                        <th scope="col" style="width: 4rem">
                             <div title="Open in New Tab">New Tab</div>
                         </th>
-                        <th scope="col" style="width: 3.25rem">
+                        <th scope="col" style="width: 6rem">
                             <div class="slds-assistive-text" title="Actions">Actions</div>
                         </th>
                     </tr>
@@ -65,6 +70,11 @@
 
     <template id="tr_template">
         <tr class="tab">
+            <td data-label="Reorder">
+                <div class="slds-form-element__control">
+                    <input type="radio" name="reorder">
+                </div>
+            </td>
             <td data-label="Tab Name" scope="row">
                 <div class="slds-form-element__control">
                     <input type="text" name="tabTitle" class="tabTitle slds-input" placeholder="Flow">

--- a/popup.js
+++ b/popup.js
@@ -18,9 +18,6 @@ function loadTabs() {
             element.querySelector(".url").value = tab.url;
             element.querySelector(".openInNewTab").checked =
                 tab.openInNewTab || false;
-            element
-                .querySelector(".delete")
-                .addEventListener("click", deleteTab);
             addRadioListener(element);
             elements.add(element);
         }
@@ -32,7 +29,6 @@ function loadTabs() {
 function addTab() {
     const template = document.getElementById(tabTemplate);
     const element = template.content.firstElementChild.cloneNode(true);
-    element.querySelector(".delete").addEventListener("click", deleteTab);
     addRadioListener(element);
     document.querySelector(tabAppendElement).append(element);
     updateSaveButtonState();
@@ -60,10 +56,14 @@ function processTabs() {
 }
 
 function deleteTab() {
-    this.closest(".tab").remove();
-    saveTab();
-    handleTabMoverButtonVisibility(); // If the selected tab was deleted, the tab-mover buttons should disappear.
-    updateSaveButtonState();
+    let selectedTab = document.querySelector(".tab.selected");
+
+    if (selectedTab) {
+        selectedTab.remove();
+        saveTab();
+        handleTabMoverButtonVisibility(); // If the selected tab was deleted, the tab-action buttons should disappear.
+        updateSaveButtonState();
+    }
 }
 
 function handleRadioSelected(event) {
@@ -146,11 +146,14 @@ function addRadioListener(tab) {
     tab.querySelector("input[type='radio']")?.addEventListener("change", handleRadioSelected);
 }
 
-const upButton = document.querySelector(".header-buttons .tab-mover.up");
+const upButton = document.querySelector(".header-buttons .tab-action.up");
 upButton.addEventListener("click", moveTabUp);
 
-const downButton = document.querySelector(".header-buttons .tab-mover.down");
+const downButton = document.querySelector(".header-buttons .tab-action.down");
 downButton.addEventListener("click", moveTabDown);
+
+const deleteButton = document.querySelector(".header-buttons .delete");
+deleteButton.addEventListener("click", deleteTab);
 
 const saveButton = document.querySelector(".save");
 saveButton.addEventListener("click", saveTab);

--- a/popup.js
+++ b/popup.js
@@ -95,8 +95,7 @@ function moveTabDown() {
         tabData.selected  = selectedRadio?.closest(".tab");
 
         let selectedIsFirst = tabData.selected == tabData.all[0];
-        let selectedIsLast  = tabData.selected == tabData.all[tabData.length - 1];
-        
+        let selectedIsLast  = tabData.selected == tabData.all[tabData.all.length - 1];
         tabData.previous = selectedIsFirst ? null : tabData.selected?.previousSibling;
         tabData.next     = selectedIsLast  ? null : tabData.selected?.nextSibling;
 


### PR DESCRIPTION
Complete tab reordering solution. There's a lot to it:

- A new column for selecting a tab to move
- New buttons at the to of the page (if a tab is selected) to allow moving the tab up or down
- Lots of logic to properly handle adding event listeners, moving the tabs, and managing the visibility of the arrow buttons
- Also widened the popup window to support the new column and a bit more space for the link text